### PR TITLE
Talos Linux Image Factory based bootstrapping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ FROM base as talosctl
 
 RUN apt-get update -qq && apt-get install --no-install-recommends -y wget
 
-ARG TALOS_VERSION=1.9.5
+ARG TALOS_VERSION=1.10.4
 # Determine the correct binary suffix based on the target platform
 RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
       export TALOS_SUFFIX="-arm64"; \

--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ Once the build has completed you should be able to access Talos Manager at `<nam
 
 #### Deploying with a specific talos version
 
-If you need to support a legacy version of Talos you can set the `TALOS_AMD64_IMAGE_URL` and `TALOS_ARM64_IMAGE_URL` ENV variables to point to the specific version you need. You will also need to manually build the docker container using the `TALOS_VERSION` build arg. Eg:
+Talos version can be configured on the Settings page of the application.
+
+However, to support configuration generation in legacy versions you may also need to manually build the docker container using the appropriate `TALOS_VERSION` build arg. Eg:
 
 ```
 docker build --platform linux/amd64 --build-arg TALOS_VERSION=1.3.7 -t registry.heroku.com/<heroku-app-name>/web .
@@ -272,7 +274,7 @@ Control plane example:
 
 ```bash
 NODE=control-plane-1
-IMAGE=ghcr.io/siderolabs/installer:v1.10.1
+IMAGE=ghcr.io/siderolabs/installer:v1.10.4
 talosctl etcd forfeit-leadership -n $NODE &&
  kubectl drain $NODE --ignore-daemonsets --delete-emptydir-data &&
  time talosctl upgrade --debug --image $IMAGE -n $NODE &&
@@ -285,7 +287,7 @@ Worker example:
 
 ```bash
 NODE=worker-1
-IMAGE=ghcr.io/siderolabs/installer:v1.10.1
+IMAGE=ghcr.io/siderolabs/installer:v1.10.4
 kubectl drain $NODE --ignore-daemonsets --delete-emptydir-data &&
  time talosctl upgrade --preserve --debug --image $IMAGE -n $NODE &&
  kubectl uncordon $NODE

--- a/app/api/talos_image_factory.rb
+++ b/app/api/talos_image_factory.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+# API docs: https://github.com/siderolabs/image-factory?tab=readme-ov-file#http-frontend-api
+
+module TalosImageFactory
+  HttpError = Class.new(StandardError)
+
+  BASE_URL = "https://factory.talos.dev"
+  ARCHITECTURES = %w[amd64 arm64].freeze
+  DEFAULT_VERSION = "v1.10.4"
+
+  def self.available_versions
+    response = Typhoeus.get("#{BASE_URL}/versions")
+
+    raise HttpError, "#{response.code}, #{response.body}" unless response.success?
+
+    JSON.parse(response.body)
+  end
+
+  def self.schematic_cmdline(schematic_id)
+    response = Typhoeus.get("#{BASE_URL}/image/#{schematic_id}/#{DEFAULT_VERSION}/cmdline-metal-amd64")
+
+    return nil if response.code == 404
+
+    raise HttpError, "#{response.code}, #{response.body}" unless response.success?
+
+    response.body
+  end
+
+  def self.image_url(
+      architecture:,
+      schematic_id: TalosImageFactorySetting.first&.schematic_id,
+      version: DEFAULT_VERSION,
+      platform: "metal"
+    )
+    raise ArgumentError, "Unsupported architecture: #{architecture}" unless ARCHITECTURES.include?(architecture)
+
+    if architecture == "arm64" && ENV["TALOS_ARM64_IMAGE_URL"].present?
+      return ENV["TALOS_ARM64_IMAGE_URL"]
+    elsif architecture == "amd64" && ENV["TALOS_AMD64_IMAGE_URL"].present?
+      return ENV["TALOS_AMD64_IMAGE_URL"]
+    end
+
+    schematic_id ||= create_schematic_with_talos_config.fetch("id")
+
+    "#{BASE_URL}/image/#{schematic_id}/#{version}/#{platform}-#{architecture}.raw.zst"
+  end
+
+  def self.create_schematic_with_talos_config
+    response = Typhoeus.post(
+      "#{BASE_URL}/schematics",
+      body: {
+        customization: {
+          extraKernelArgs: [
+            "talos.config=https://#{ENV.fetch("HOST")}/config",
+          ],
+        },
+      }.to_json,
+    )
+
+    raise HttpError, "#{response.code}, #{response.body}" unless response.success?
+
+    JSON.parse(response.body)
+  end
+end

--- a/app/controllers/configs_controller.rb
+++ b/app/controllers/configs_controller.rb
@@ -26,7 +26,7 @@ class ConfigsController < ApplicationController
   def new
     @config = Config.new(
       kubernetes_version: "1.30.1",
-      install_image: "ghcr.io/siderolabs/installer:v1.9.5",
+      install_image: "ghcr.io/siderolabs/installer:v1.10.4",
       kubespan: true,
     )
   end

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,5 +1,6 @@
 class SettingsController < ApplicationController
   def show
     @api_keys = ApiKey.all
+    @talos_image_factory_setting = TalosImageFactorySetting.first_or_create!
   end
 end

--- a/app/controllers/talos_image_factory_settings_controller.rb
+++ b/app/controllers/talos_image_factory_settings_controller.rb
@@ -1,0 +1,18 @@
+class TalosImageFactorySettingsController < ApplicationController
+  def update
+    @talos_image_factory_setting = TalosImageFactorySetting.first_or_create!
+
+    talos_image_factory_setting_params = params.require(:talos_image_factory_setting).permit(
+      :version,
+      :schematic_id,
+    )
+
+    if @talos_image_factory_setting.update(talos_image_factory_setting_params)
+      # redirect_to settings_path, status: 303, notice: "Talos Image Factory settings updated successfully."
+      flash.now[:talos_image_factory_update_notice] = "Talos Image Factory settings updated successfully."
+      render :edit
+    else
+      render :edit, status: 422
+    end
+  end
+end

--- a/app/form_builders/application_form_builder.rb
+++ b/app/form_builders/application_form_builder.rb
@@ -50,6 +50,8 @@ class ApplicationFormBuilder < ActionView::Helpers::FormBuilder
   def submit(label, options = {})
     options[:class] = SUBMIT_CLASSES
 
+    options[:class] = options[:class].sub("w-full", "w-auto") if options.delete(:auto_width)
+
     super
   end
 

--- a/app/models/talos_image_factory_setting.rb
+++ b/app/models/talos_image_factory_setting.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# This is currently used as a singleton model that stores the Talos Image Factory settings.
+# Could potentially be extended to support multiple settings records in the future.
+
+class TalosImageFactorySetting < ApplicationRecord
+  attribute :version, :string, default: "v1.10.4"
+
+  validates_presence_of :version
+
+  validate :validate_existing_version, if: -> { version.present? && version_changed? }
+  validate :validate_schematic, if: -> { schematic_id.present? && schematic_id_changed? }
+
+  private
+
+  # - Version must match an available Talos version
+  def validate_existing_version
+    available_versions = TalosImageFactory.available_versions
+
+    return if available_versions.include?(version)
+
+    errors.add(:version, "is not a valid Talos version. Available versions: #{available_versions.to_sentence}")
+  rescue TalosImageFactory::HttpError => e
+    errors.add(:base, "Failed to fetch available Talos versions: #{e.message}")
+  end
+
+  # - Schematic must exist
+  # - Schematic must contain a talos.config= kernel command line argument
+  # - talos.config= must point to https://<HOST>/config
+  def validate_schematic
+    cmdline = TalosImageFactory.schematic_cmdline(schematic_id)
+
+    if cmdline.nil?
+      errors.add(:schematic_id, "could not find this schematic ID in the Talos Image Factory")
+      return
+    end
+
+    expected_url = "https://#{ENV.fetch('HOST')}/config"
+    talos_config_match = cmdline.match(/talos\.config=(https?:\/\/[^\s]+)/)
+
+    if talos_config_match.nil?
+      errors.add(:schematic_id, "must contain a talos.config=#{expected_url} kernel command line argument")
+      return
+    end
+
+    talos_config_url = talos_config_match[1]
+    unless talos_config_url.start_with?("")
+      errors.add(:schematic_id, "had a talos.config= kernel argument pointing to #{talos_config_url}, but it must point to #{expected_url}")
+    end
+  rescue TalosImageFactory::HttpError => e
+    errors.add(:base, "Failed to validate schematic ID: #{e.message}")
+  end
+end

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -1,12 +1,14 @@
 <h1 class="text-4xl mb-10">Settings</h1>
 
+<hr class="mb-10">
+
 <div class="flex mb-10 items-center justify-between">
   <h2 class="text-2xl mb-5">API Keys</h2>
   <%= link_to "New API Key", new_api_key_path, class: "text-white rounded bg-mnd-red hover:bg-mnd-red-dark font-semibold p-3" %>
 </div>
 
-<% if @api_keys.any? %>
-  <table id="server-table" class="mb-5">
+<% if @api_keys&.any? %>
+  <table id="server-table" class="mb-20">
     <thead class="text-lg text-left">
       <th class="">Provider</th>
       <th class="">Name</th>
@@ -32,3 +34,15 @@
     </tbody>
   </table>
 <% end %>
+
+<hr class="mb-10">
+
+<div class="mb-10">
+  <h2 class="text-2xl mb-5">Talos Linux Image Factory</h2>
+  <p>
+    <%= link_to "Talos Linux Image Factory", "https://factory.talos.dev/", class: "text-blue-600 hover:underline", target: "_blank" %>
+    is used to generate the Talos Linux bootstrap image. Modify these settings to change the default image used when creating new servers. Note that if you create your own factory schematic you must add <code class="bg-gray-100 p-1">talos.config=https://<%= ENV["HOST"] %>/config</code> to kernel command line arguments for your schematic to work.
+  </p>
+</div>
+
+<%= render partial: "talos_image_factory_settings/form", locals: { talos_image_factory_setting: @talos_image_factory_setting } %>

--- a/app/views/talos_image_factory_settings/_form.html.erb
+++ b/app/views/talos_image_factory_settings/_form.html.erb
@@ -1,0 +1,23 @@
+<%= turbo_frame_tag talos_image_factory_setting do %>
+  <%= form_with model: talos_image_factory_setting do |f| %>
+    <%= f.text_field :version, label: "Talos Version" %>
+    <%= f.text_field :schematic_id, label: "Schematic ID", required: false, hint: "Optionally use the Talos Linux Image Factory to create a custom schematic and paste the ID here. Useful for enabling extensions like nvidia drivers, mdadm etc. Don't forget to include the talos.config kernel command line argument as mentioned above." %>
+    <%= f.submit "Update Factory Image settings", auto_width: true %>
+  <% end %>
+
+  <%# Sloppy copy paste from the application/flash partial to work around Turbo's inability %>
+  <%# to break out of a frame on redirect. On a successful form submission we set flash.now[:notice] %>
+  <%# to ensure a toast is presented to the user. %>
+  <dialog class="bottom-0 w-full bg-transparent" <%= "open" if flash[:talos_image_factory_update_notice] %>>
+    <div
+      class="flex bg-white shadow rounded opacity-0 -bottom-20 left-8 fixed p-3 items-center justify-between"
+      style="animation: flash 10s; animation-iteration-count: 1;"
+    >
+      <div class="bg-green-100 rounded-lg text-green-600 p-2 ml-2 mr-4"><%= icon_checkmark %></div>
+      <p class="mr-3 text-gray-800"><%= flash[:talos_image_factory_update_notice] %></p>
+      <form method="dialog" class="flex items-center">
+        <button type="submit" class="text-gray-500 hover:text-gray-800"><%= icon_cross %></button>
+      </form>
+    </div>
+  </dialog>
+<% end %>

--- a/app/views/talos_image_factory_settings/edit.html.erb
+++ b/app/views/talos_image_factory_settings/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "form", locals: { talos_image_factory_setting: @talos_image_factory_setting } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
       end
     end
     resource :settings, only: %i[show]
+    resources :talos_image_factory_settings, only: %i[update]
   end
 
   get "config", to: "configs#show", as: "get_config"

--- a/db/migrate/20250702112740_create_talos_image_factory_settings.rb
+++ b/db/migrate/20250702112740_create_talos_image_factory_settings.rb
@@ -1,0 +1,10 @@
+class CreateTalosImageFactorySettings < ActiveRecord::Migration[7.2]
+  def change
+    create_table :talos_image_factory_settings do |t|
+      t.string :version, null: false
+      t.string :schematic_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_06_30_185032) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_02_112740) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -90,6 +90,13 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_30_185032) do
     t.index ["hetzner_vswitch_id"], name: "index_servers_on_hetzner_vswitch_id"
     t.index ["ip"], name: "index_servers_on_ip", unique: true
     t.index ["type"], name: "index_servers_on_type"
+  end
+
+  create_table "talos_image_factory_settings", force: :cascade do |t|
+    t.string "version", null: false
+    t.string "schematic_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   add_foreign_key "clusters", "hetzner_vswitches"

--- a/spec/models/machine_config_spec.rb
+++ b/spec/models/machine_config_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe MachineConfig do
       server = Server.new(name: "worker-1", ip: "72.14.201.110", cluster:)
       config = Config.new(
         name: "config",
-        install_image: "ghcr.io/siderolabs/installer:v1.9.5",
+        install_image: "ghcr.io/siderolabs/installer:v1.10.4",
         kubernetes_version: "1.30.1",
         kubespan: true,
         patch: <<~YAML,
@@ -105,7 +105,7 @@ RSpec.describe MachineConfig do
               enabled: true
           install:
             disk: "/dev/nvme0n1"
-            image: ghcr.io/siderolabs/installer:v1.9.5
+            image: ghcr.io/siderolabs/installer:v1.10.4
             wipe: false
           features:
             rbac: true


### PR DESCRIPTION
### WHY

Post Talos version 1.10 it is no longer possible to hack grub config to set the talos.config kernel parameter.

### WHAT

As an alternative we're migrating to using the official Talos Linux Image Factory to bake talos.config into the install image. In addition we can now leverage the factory's support for adding useful extensions like nvidia drivers, mdadm etc.

The recently added Settings page gets an additional section for configuring Talos version and optionally a custom factory schematic.

<img width="1141" alt="Screenshot 2025-07-02 at 18 15 40" src="https://github.com/user-attachments/assets/56a502d5-df76-4a45-aa16-85836012b1d1" />
