### PR TITLE
Automatically apply labels and taints after successful configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,10 @@ RUN rm -rf vendor/bundle/ruby/*/cache
 
 FROM base
 
+# kubectl for kubernetes integration
+
+COPY --from=bitnami/kubectl:1.33.3 /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/kubectl
+
 # wget for talosctl installation
 # curl is required for typhoeus and the heroku release command output
 # libsqlite3-0 for sqlite3

--- a/app/controllers/configs_controller.rb
+++ b/app/controllers/configs_controller.rb
@@ -13,12 +13,29 @@ class ConfigsController < ApplicationController
       # Render config before updating in case it would fail for whatever reason
       config = server.machine_config.generate_config
 
+      labeling_job_maybe_already_running = server.last_configured_at && server.last_configured_at > 10.minutes.ago
+
       # Using 1.second.ago seems silly but is required to show the correct status in the UI at the moment
-      server.update!(last_request_for_configuration_at: 1.second.ago, last_configured_at: Time.now)
+      server.update!(
+        last_request_for_configuration_at: 1.second.ago,
+        last_configured_at: Time.now,
+        # Don't touch this attribute in case a labeling job could be running to avoid hypothetical race condition
+        label_and_taint_job_completed_at: labeling_job_maybe_already_running ? server.label_and_taint_job_completed_at : nil,
+      )
+
+      # We have to be cautious about scheduling this job since the requesting server may be
+      # rejecting the configuration we're returning. If this is the case the requesting server
+      # will keep on hitting this endpoint until it gets a configuration that it accepts.
+      LabelAndTaintJob.perform_later(server.id) unless labeling_job_maybe_already_running
+
       headers["Content-Type"] = "text/yaml"
       render plain: config
     else
-      server.update!(last_configured_at: nil, last_request_for_configuration_at: Time.now)
+      server.update!(
+        last_configured_at: nil,
+        last_request_for_configuration_at: Time.now,
+        label_and_taint_job_completed_at: nil,
+      )
       render plain: "No configuration found for server with IP #{server.ip}", status: 420
     end
   end

--- a/app/controllers/label_and_taint_rules_controller.rb
+++ b/app/controllers/label_and_taint_rules_controller.rb
@@ -11,9 +11,7 @@ class LabelAndTaintRulesController < ApplicationController
   end
 
   def create
-    label_and_taint_rule_params = params.expect(
-      label_and_taint_rule: %i[match labels_comma_separated taints_comma_separated]
-    )
+    label_and_taint_rule_params = params.expect(label_and_taint_rule: %i[match labels taints])
 
     @label_and_taint_rule = LabelAndTaintRule.new(label_and_taint_rule_params)
 
@@ -31,9 +29,7 @@ class LabelAndTaintRulesController < ApplicationController
   def update
     @label_and_taint_rule = LabelAndTaintRule.find(params[:id])
 
-    label_and_taint_rule_params = params.expect(
-      label_and_taint_rule: %i[match labels_comma_separated taints_comma_separated]
-    )
+    label_and_taint_rule_params = params.expect(label_and_taint_rule: %i[match labels taints])
 
     if @label_and_taint_rule.update(label_and_taint_rule_params)
       redirect_to label_and_taint_rules_path, notice: "Label and Taint Rule updated successfully."

--- a/app/controllers/label_and_taint_rules_controller.rb
+++ b/app/controllers/label_and_taint_rules_controller.rb
@@ -1,0 +1,51 @@
+class LabelAndTaintRulesController < ApplicationController
+  def index
+    @label_and_taint_rules = LabelAndTaintRule.all
+  end
+
+  def show
+  end
+
+  def new
+    @label_and_taint_rule = LabelAndTaintRule.new
+  end
+
+  def create
+    label_and_taint_rule_params = params.expect(
+      label_and_taint_rule: %i[match labels_comma_separated taints_comma_separated]
+    )
+
+    @label_and_taint_rule = LabelAndTaintRule.new(label_and_taint_rule_params)
+
+    if @label_and_taint_rule.save
+      redirect_to label_and_taint_rules_path, notice: "Label and Taint Rule created successfully."
+    else
+      render :new, status: 422
+    end
+  end
+
+  def edit
+    @label_and_taint_rule = LabelAndTaintRule.find(params[:id])
+  end
+
+  def update
+    @label_and_taint_rule = LabelAndTaintRule.find(params[:id])
+
+    label_and_taint_rule_params = params.expect(
+      label_and_taint_rule: %i[match labels_comma_separated taints_comma_separated]
+    )
+
+    if @label_and_taint_rule.update(label_and_taint_rule_params)
+      redirect_to label_and_taint_rules_path, notice: "Label and Taint Rule updated successfully."
+    else
+      render :edit, status: 422
+    end
+  end
+
+  def destroy
+    label_and_taint_rule = LabelAndTaintRule.find(params[:id])
+    label_and_taint_rule.destroy
+
+    redirect_to label_and_taint_rules_path, notice: "Label and Taint Rule deleted successfully."
+  end
+end

--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -32,7 +32,12 @@ class ServersController < ApplicationController
     server = Server.find(params[:id])
 
     # pretend it's not accessible while bootstrapping to hide bootstrap button
-    server.update!(accessible: false, last_request_for_configuration_at: nil, last_configured_at: nil)
+    server.update!(
+      accessible: false,
+      last_request_for_configuration_at: nil,
+      last_configured_at: nil,
+      label_and_taint_job_completed_at: nil,
+    )
 
     ServerBootstrapJob.perform_later(server.id)
 

--- a/app/form_builders/application_form_builder.rb
+++ b/app/form_builders/application_form_builder.rb
@@ -60,7 +60,9 @@ class ApplicationFormBuilder < ActionView::Helpers::FormBuilder
   def input_with_label_and_validation(attribute, options = {})
     options[:class] = "#{INPUT_CLASSES} #{options[:class]}"
     options[:required] = true unless options.key?(:required)
-    validation_errors = object.errors[attribute].to_sentence.capitalize.presence
+    validation_errors = object.errors[attribute].to_sentence.presence
+    validation_errors[0] = validation_errors[0].upcase if validation_errors
+
     hint_margins = options.delete(:type) == "textarea" ? "-mt-4 mb-5" : "-mt-2 mb-4"
 
     label =

--- a/app/jobs/label_and_taint_job.rb
+++ b/app/jobs/label_and_taint_job.rb
@@ -44,7 +44,7 @@ class LabelAndTaintJob < ApplicationJob
       Rails.logger.info "No matching label and taint rules found for server #{server.name}"
     end
 
-    labels = matching_rules.flat_map(&:labels).compact.uniq
+    labels = matching_rules.flat_map(&:labels_as_array).compact.uniq
     if labels.any?
       success, _, stderr = kubectl.run("label node #{server.name} --overwrite #{labels.join(' ')}")
 
@@ -53,7 +53,7 @@ class LabelAndTaintJob < ApplicationJob
       end
     end
 
-    taints = matching_rules.flat_map(&:taints).compact.uniq
+    taints = matching_rules.flat_map(&:taints_as_array).compact.uniq
     if taints.any?
       success, _, stderr = kubectl.run("taint node #{server.name} #{taints.join(' ')}")
       unless success

--- a/app/jobs/label_and_taint_job.rb
+++ b/app/jobs/label_and_taint_job.rb
@@ -1,0 +1,68 @@
+# Intended to be run after a server is configured. It is expected that the reboot after configuration
+# is applied can take a while which is why we keep retrying for some time (and eventually give up).
+
+class LabelAndTaintJob < ApplicationJob
+  def perform(server_id)
+    server = Server.find(server_id)
+
+    # We may be waiting for the first control plane server to be ready
+    kubectl =
+      30.times do |attempt|
+        break server.kubectl
+      rescue Cluster::NoControlPlaneError, Talosctl::ConnectionRefusedError
+        Rails.logger.warn "Attempt #{attempt + 1}/30: No control plane found for server #{server.name}. Retrying in 10 seconds..."
+        sleep 10 unless Rails.env.test?
+      end
+
+    unless kubectl.is_a?(Kubectl)
+      Rails.logger.error "Failed to get kubectl for server #{server.name} after 30 attempts, aborting"
+      return
+    end
+
+    # Wait 5 minutes for the server to be present in the cluster
+    server_present =
+      60.times.find do |attempt|
+        success, _stdout, stderr = kubectl.run("get node #{server.name}")
+
+        break true if success
+
+        Rails.logger.warn "Attempt #{attempt + 1}/30: Waiting for #{server.name}. Output: #{stderr}. Retrying in 10 seconds..."
+        sleep 5 unless Rails.env.test?
+        false
+      end
+
+    unless server_present
+      Rails.logger.error "Failed to confirm #{server.name} in the cluster after 30 attempts, aborting"
+      return
+    end
+
+    matching_rules = LabelAndTaintRule.all.entries.select do |rule|
+      server.name.include?(rule.match)
+    end
+
+    if matching_rules.empty?
+      Rails.logger.info "No matching label and taint rules found for server #{server.name}"
+    end
+
+    labels = matching_rules.flat_map(&:labels).compact.uniq
+    if labels.any?
+      success, _, stderr = kubectl.run("label node #{server.name} --overwrite #{labels.join(' ')}")
+
+      unless success
+        Rails.logger.error "Failed to apply labels to server #{server.name}: #{stderr}"
+      end
+    end
+
+    taints = matching_rules.flat_map(&:taints).compact.uniq
+    if taints.any?
+      success, _, stderr = kubectl.run("taint node #{server.name} #{taints.join(' ')}")
+      unless success
+        Rails.logger.error "Failed to apply taints to server #{server.name}: #{stderr}"
+      end
+    end
+
+    # Whether we actually applied any labels or taints we set label_and_taint_job_completed_at
+    # to indicate that we have at least confirmed the server to be present in the cluster.
+    server.update!(label_and_taint_job_completed_at: Time.now)
+  end
+end

--- a/app/models/kubectl.rb
+++ b/app/models/kubectl.rb
@@ -1,0 +1,29 @@
+require "open3"
+
+# Wrapper around the kubectl command line tool to interact with Kubernetes clusters
+
+class Kubectl
+  def initialize(config_string)
+    @config_string = config_string
+  end
+
+  def run(command)
+    command = "kubectl --kubeconfig=#{config_file.path} #{command}"
+    Rails.logger.info "[Kubectl] Running command: #{command}"
+
+    Open3.popen3(command) do |_stdin, stdout, stderr, wait_thread|
+      [wait_thread.value.success?, stdout.read, stderr.read]
+    end
+  end
+
+  private
+
+  def config_file
+    return @config_file if defined?(@config_file)
+
+    @config_file = Tempfile.new("kubeconfig").tap do |file|
+      file.write(@config_string)
+      file.flush
+    end
+  end
+end

--- a/app/models/label_and_taint_rule.rb
+++ b/app/models/label_and_taint_rule.rb
@@ -1,0 +1,101 @@
+class LabelAndTaintRule < ApplicationRecord
+  validates_presence_of :match
+  validate :at_least_one_label_or_taint
+  validate :validate_labels
+  validate :validate_taints
+
+  def labels_comma_separated
+    labels.join(",")
+  end
+
+  def labels_comma_separated=(value)
+    self.labels = value.split(",").map(&:strip).compact_blank
+  end
+
+  def taints_comma_separated
+    taints.join(",")
+  end
+
+  def taints_comma_separated=(value)
+    self.taints = value.split(",").map(&:strip).compact_blank
+  end
+
+  private
+
+  def at_least_one_label_or_taint
+    if labels.blank? && taints.blank?
+      errors.add(:labels_comma_separated, "At least one label or taint must be provided.")
+      errors.add(:taints_comma_separated, "At least one label or taint must be provided.")
+    end
+  end
+
+  # This validation approximates the official standard for kubernetes labels, but not precisely:
+  #
+  # Labels are key/value pairs. Valid label keys have two segments: an optional prefix and name, separated by a
+  # slash (/). The name segment is required and must be 63 characters or less, beginning and ending with an
+  # alphanumeric character ([a-z0-9A-Z]) with dashes (-), underscores (_), dots (.), and alphanumerics between.
+  # The prefix is optional. If specified, the prefix must be a DNS subdomain: a series of DNS labels separated by
+  # dots (.), not longer than 253 characters in total, followed by a slash (/).
+  #
+  # If the prefix is omitted, the label Key is presumed to be private to the user. Automated system components
+  # (e.g. kube-scheduler, kube-controller-manager, kube-apiserver, kubectl, or other third-party automation) which
+  # add labels to end-user objects must specify a prefix.
+  #
+  # The kubernetes.io/ and k8s.io/ prefixes are reserved for Kubernetes core components.
+  #
+  # Valid label value:
+  #   - must be 63 characters or less (can be empty),
+  #   - unless empty, must begin and end with an alphanumeric character ([a-z0-9A-Z]),
+  #   - could contain dashes (-), underscores (_), dots (.), and alphanumerics between.
+  def validate_labels
+    labels.each do |label|
+      error = validate_label(label)
+      errors.add(:labels_comma_separated, error) if error
+    end
+  end
+
+  # Via https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#taint
+  # A taint consists of a key, value, and effect. As an argument here, it is expressed as key=value:effect.
+  # The key must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores, up to 253 characters.
+  # Optionally, the key can begin with a DNS subdomain prefix and a single '/', like example.com/my-app.
+  # The value is optional. If given, it must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores, up to 63 characters.
+  # The effect must be NoSchedule, PreferNoSchedule or NoExecute.
+  def validate_taints
+    taints.each do |taint|
+      if taint.exclude?(":")
+        errors.add(:taints_comma_separated, "must be in the format of key=value:Effect")
+        return
+      end
+
+      label, effect = taint.split(":", 2)
+
+      if %w[NoSchedule PreferNoSchedule NoExecute].exclude?(effect)
+        errors.add(:taints_comma_separated, "effect must be one of: NoSchedule, PreferNoSchedule, NoExecute")
+        return
+      end
+
+      error = validate_label(label)
+      errors.add(:taints_comma_separated, error) if error
+    end
+  end
+
+  def validate_label(label)
+    if label.exclude?("=")
+      return "must include an equals sign to separate key and value"
+    end
+
+    key, value = label.split("=", 2)
+
+    if key.blank? || key.length > 316
+      return "keys must be between 1 and 316 characters long"
+    end
+
+    unless key.match?(/\A(([A-Za-z0-9][-A-Za-z0-9_.\/]*)?[A-Za-z0-9])?\z/)
+      return "keys must consist of alphanumeric characters, '-', '_', '/' or '.', and must start and end with an alphanumeric character (this validation is stricter than Kubernetes itself but let's be reasonable)." # rubocop:disable Layout/LineLength
+    end
+
+    unless value.match?(/\A(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?\z/)
+      return "values must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character." # rubocop:disable Layout/LineLength
+    end
+  end
+end

--- a/app/models/machine_config.rb
+++ b/app/models/machine_config.rb
@@ -145,6 +145,10 @@ class MachineConfig < ApplicationRecord
   end
 
   def set_configured
-    server.update!(last_configured_at: Time.now, last_request_for_configuration_at: Time.at(0))
+    server.update!(
+      last_configured_at: Time.now,
+      last_request_for_configuration_at: Time.at(0),
+      label_and_taint_job_completed_at: Time.at(0),
+    )
   end
 end

--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -100,6 +100,16 @@ class Server < ApplicationRecord
     update!(accessible: false)
   end
 
+  def talosctl
+    raise "ERROR: Can't use talosctl without a cluster" unless cluster
+
+    @talosctl ||= Talosctl.new(cluster.talosconfig)
+  end
+
+  def kubectl
+    @kubectl ||= Kubectl.new(talosctl.kubeconfig)
+  end
+
   def rescue
     raise "#rescue is not implemented for #{self.class.name}"
   end
@@ -120,7 +130,7 @@ class Server < ApplicationRecord
     Rails.logger.info "class=Server method=reset name='#{name}' command='#{command}'"
     if (success = system(command))
       machine_config&.destroy!
-      update!(last_configured_at: nil, last_request_for_configuration_at: nil)
+      update!(last_configured_at: nil, last_request_for_configuration_at: nil, label_and_taint_job_completed_at: nil)
     end
     success
   end

--- a/app/views/label_and_taint_rules/_form.html.erb
+++ b/app/views/label_and_taint_rules/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with model: model do |f| %>
   <%= f.text_field :match, placeholder: "database", autofocus: model.new_record?, hint: "The match will be applied to server names via a simple inclusion check. Eg. 'database' will match 'database-6' as well as 'staging-database-3'." %>
-  <%= f.text_field :labels_comma_separated, label: "Labels", placeholder: "node-role.kubernetes.io/database=", required: false, hint: "Multiple labels can be separated by comma." %>
-  <%= f.text_field :taints_comma_separated, label: "Taints", placeholder: "role=database:NoSchedule", required: false, hint: "Multiple taints can be separated by comma." %>
+  <%= f.text_field :labels, placeholder: "node-role.kubernetes.io/database=", required: false, hint: "Multiple labels can be separated by comma." %>
+  <%= f.text_field :taints, placeholder: "role=database:NoSchedule", required: false, hint: "Multiple taints can be separated by comma." %>
 
   <%= f.submit "Save" %>
 <% end %>

--- a/app/views/label_and_taint_rules/_form.html.erb
+++ b/app/views/label_and_taint_rules/_form.html.erb
@@ -1,0 +1,7 @@
+<%= form_with model: model do |f| %>
+  <%= f.text_field :match, placeholder: "database", autofocus: model.new_record?, hint: "The match will be applied to server names via a simple inclusion check. Eg. 'database' will match 'database-6' as well as 'staging-database-3'." %>
+  <%= f.text_field :labels_comma_separated, label: "Labels", placeholder: "node-role.kubernetes.io/database=", required: false, hint: "Multiple labels can be separated by comma." %>
+  <%= f.text_field :taints_comma_separated, label: "Taints", placeholder: "role=database:NoSchedule", required: false, hint: "Multiple taints can be separated by comma." %>
+
+  <%= f.submit "Save" %>
+<% end %>

--- a/app/views/label_and_taint_rules/edit.html.erb
+++ b/app/views/label_and_taint_rules/edit.html.erb
@@ -1,0 +1,3 @@
+<h1 class="text-4xl mb-10">Edit Label & Taint Rule</h1>
+
+<%= render "form", model: @label_and_taint_rule %>

--- a/app/views/label_and_taint_rules/index.html.erb
+++ b/app/views/label_and_taint_rules/index.html.erb
@@ -1,0 +1,35 @@
+<div class="flex mb-10 items-center justify-between">
+  <h1 class="text-4xl">Label and Taint Rules</h1>
+  <%= link_to "New Rule", new_label_and_taint_rule_path, class: "text-white rounded bg-mnd-red hover:bg-mnd-red-dark font-semibold p-3" %>
+</div>
+
+<p class="mb-10">
+  Label and Taint rules will be applied to servers after they have been configured and successfully joined a cluster. Use them to avoid having to manually apply labels like <code>node-role.kubernetes.io/database=</code> to database nodes etc.
+</p>
+
+<% if @label_and_taint_rules.any? %>
+  <table>
+    <thead>
+      <tr>
+        <th class="text-left">Match</th>
+        <th class="text-left">Labels</th>
+        <th class="text-left">Taints</th>
+        <th class="text-left">Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% none = %(<span class="text-gray-400">none</span>).html_safe %>
+      <% @label_and_taint_rules.each do |label_and_taint_rule| %>
+        <tr class="h-11 hover:bg-gray-50">
+          <td class="mr-5"><%= label_and_taint_rule.match %></td>
+          <td class="mr-5"><%= label_and_taint_rule.labels.to_sentence.presence || none %></td>
+          <td class="mr-5"><%= label_and_taint_rule.taints.to_sentence.presence || none %></td>
+          <td class="flex gap-2">
+            <%= link_to "Edit", edit_label_and_taint_rule_path(label_and_taint_rule), class: "text-white text-sm rounded bg-mnd-red hover:bg-mnd-red-dark font-semibold px-3 py-2" %>
+            <%= button_to icon_trash("w-5"), label_and_taint_rule_path(label_and_taint_rule), method: :delete, data: { turbo_confirm: "Sure you want to destroy the label and taint rule matching #{label_and_taint_rule.match}?" }, class: "text-white text-sm rounded bg-mnd-red hover:bg-mnd-red-dark font-semibold px-3 py-2" %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/label_and_taint_rules/index.html.erb
+++ b/app/views/label_and_taint_rules/index.html.erb
@@ -22,8 +22,8 @@
       <% @label_and_taint_rules.each do |label_and_taint_rule| %>
         <tr class="h-11 hover:bg-gray-50">
           <td class="mr-5"><%= label_and_taint_rule.match %></td>
-          <td class="mr-5"><%= label_and_taint_rule.labels.to_sentence.presence || none %></td>
-          <td class="mr-5"><%= label_and_taint_rule.taints.to_sentence.presence || none %></td>
+          <td class="mr-5"><%= label_and_taint_rule.labels_as_array.to_sentence.presence || none %></td>
+          <td class="mr-5"><%= label_and_taint_rule.taints_as_array.to_sentence.presence || none %></td>
           <td class="flex gap-2">
             <%= link_to "Edit", edit_label_and_taint_rule_path(label_and_taint_rule), class: "text-white text-sm rounded bg-mnd-red hover:bg-mnd-red-dark font-semibold px-3 py-2" %>
             <%= button_to icon_trash("w-5"), label_and_taint_rule_path(label_and_taint_rule), method: :delete, data: { turbo_confirm: "Sure you want to destroy the label and taint rule matching #{label_and_taint_rule.match}?" }, class: "text-white text-sm rounded bg-mnd-red hover:bg-mnd-red-dark font-semibold px-3 py-2" %>

--- a/app/views/label_and_taint_rules/new.html.erb
+++ b/app/views/label_and_taint_rules/new.html.erb
@@ -1,0 +1,3 @@
+<h1 class="text-4xl mb-10">New Label & Taint Rule</h1>
+
+<%= render "form", model: @label_and_taint_rule %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -48,6 +48,7 @@
         <%= link_to "Servers", servers_path, class: "text-l hover:underline underline-offset-2 #{'underline' if params[:controller] == 'servers'}" %>
         <%= link_to "Clusters", clusters_path, class: "text-l hover:underline underline-offset-2 #{'underline' if params[:controller] == 'clusters'}" %>
         <%= link_to "Configs", configs_path, class: "text-l hover:underline underline-offset-2 #{'underline' if params[:controller] == 'configs'}" %>
+        <%= link_to "Label & Taint Rules", label_and_taint_rules_path, class: "text-l hover:underline underline-offset-2 #{'underline' if params[:controller] == 'label_and_taint_rules'}" %>
       </div>
       <%# right side of nav %>
       <div class="ml-auto flex items-center">

--- a/app/views/servers/_server_status.html.erb
+++ b/app/views/servers/_server_status.html.erb
@@ -3,7 +3,8 @@
     <% if server.last_request_for_configuration_at %>
       <% if server.configured? %>
         <% if server.config %>
-          <span class="block h-4 w-4 mr-4 rounded-full bg-green-400"></span>
+          <% in_cluster_border = "border-2 border-green-500" if server.label_and_taint_job_completed_at %>
+          <span class="block h-4 w-4 mr-4 rounded-full bg-green-400 <%= in_cluster_border %>"></span>
         <% else %>
           <span
             class="block h-4 w-4 mr-4 rounded-full border-1 bg-green-100"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
         get :kubeconfig
       end
     end
+    resources :label_and_taint_rules, only: %i[index new create edit update destroy]
     resources :machine_configs, only: %i[show new create destroy]
     resources :servers, only: %i[index edit update] do
       collection do

--- a/db/migrate/20250723092356_create_label_and_taint_rules.rb
+++ b/db/migrate/20250723092356_create_label_and_taint_rules.rb
@@ -1,0 +1,11 @@
+class CreateLabelAndTaintRules < ActiveRecord::Migration[8.0]
+  def change
+    create_table :label_and_taint_rules do |t|
+      t.string :match, null: false
+      t.string :labels, array: true, null: false, default: []
+      t.string :taints, array: true, null: false, default: []
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250723140542_add_labeled_and_tainted_at_to_servers.rb
+++ b/db/migrate/20250723140542_add_labeled_and_tainted_at_to_servers.rb
@@ -1,0 +1,5 @@
+class AddLabeledAndTaintedAtToServers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :servers, :label_and_taint_job_completed_at, :datetime
+  end
+end

--- a/db/migrate/20250724070230_change_taints_and_labels_to_regular_strings.rb
+++ b/db/migrate/20250724070230_change_taints_and_labels_to_regular_strings.rb
@@ -1,0 +1,33 @@
+class ChangeTaintsAndLabelsToRegularStrings < ActiveRecord::Migration[8.0]
+  def up
+    existing = ApplicationRecord.connection
+      .query("SELECT id,array_to_string(labels, ','),array_to_string(taints, ',') FROM label_and_taint_rules")
+
+    remove_column :label_and_taint_rules, :labels
+    remove_column :label_and_taint_rules, :taints
+
+    add_column :label_and_taint_rules, :labels, :string
+    add_column :label_and_taint_rules, :taints, :string
+
+    existing.each do |row|
+      id, labels, taints = row
+      LabelAndTaintRule.where(id:).update_all(labels: labels, taints: taints)
+    end
+  end
+
+  def down
+    existing = ApplicationRecord.connection
+      .query("SELECT id,labels,taints FROM label_and_taint_rules")
+
+    remove_column :label_and_taint_rules, :labels
+    remove_column :label_and_taint_rules, :taints
+
+    add_column :label_and_taint_rules, :labels, :string, array: true, default: []
+    add_column :label_and_taint_rules, :taints, :string, array: true, default: []
+
+    existing.each do |row|
+      id, labels, taints = row
+      LabelAndTaintRule.where(id:).update_all(labels: labels.split(','), taints: taints.split(','))
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_23_140542) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_24_070230) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -55,10 +55,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_23_140542) do
 
   create_table "label_and_taint_rules", force: :cascade do |t|
     t.string "match", null: false
-    t.string "labels", default: [], null: false, array: true
-    t.string "taints", default: [], null: false, array: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "labels"
+    t.string "taints"
   end
 
   create_table "machine_configs", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_22_135751) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_23_140542) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -53,6 +53,14 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_22_135751) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "label_and_taint_rules", force: :cascade do |t|
+    t.string "match", null: false
+    t.string "labels", default: [], null: false, array: true
+    t.string "taints", default: [], null: false, array: true
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "machine_configs", force: :cascade do |t|
     t.integer "config_id", null: false
     t.integer "server_id", null: false
@@ -86,6 +94,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_22_135751) do
     t.string "architecture", default: "amd64", null: false
     t.bigint "api_key_id", null: false
     t.string "bootstrap_disk_wwid"
+    t.datetime "label_and_taint_job_completed_at"
     t.index ["api_key_id"], name: "index_servers_on_api_key_id"
     t.index ["cluster_id"], name: "index_servers_on_cluster_id"
     t.index ["hetzner_vswitch_id"], name: "index_servers_on_hetzner_vswitch_id"

--- a/spec/jobs/label_and_taint_job_spec.rb
+++ b/spec/jobs/label_and_taint_job_spec.rb
@@ -1,0 +1,58 @@
+RSpec.describe LabelAndTaintJob do
+  it "applies labels and taints to a server via kubectl and updates label_and_taint_job_completed_at" do
+    LabelAndTaintRule.create!(
+      match: "worker",
+      labels: %w[node-role.kubernetes.io/worker=],
+    )
+    LabelAndTaintRule.create!(
+      match: "database",
+      labels: %w[node-role.kubernetes.io/database=],
+      taints: %w[role=database:NoSchedule],
+    )
+
+    api_key = api_keys(:hetzner_cloud)
+    cluster = Cluster.create!(name: "test", endpoint: "https://kubernetes.localhost:6443")
+
+    server = Server.create!(
+      name: "worker-1",
+      accessible: true,
+      api_key_id: api_key.id,
+      cluster_id: cluster.id,
+      data_center: "DC1",
+      ip: "10.10.10.10",
+      ipv6: "::1",
+      product: "P",
+      status: "running",
+    )
+
+    kubectl_mock = Kubectl.new("kubeconf")
+
+    expect(kubectl_mock).to receive(:run).with("get node worker-1")
+      .and_return([true, "", ""])
+    expect(kubectl_mock).to receive(:run).with("label node worker-1 --overwrite node-role.kubernetes.io/worker=")
+      .and_return([true, "", ""])
+
+    allow_any_instance_of(Server).to receive(:kubectl).and_return(kubectl_mock)
+
+    LabelAndTaintJob.perform_now(server.id)
+
+    expect(server.reload.label_and_taint_job_completed_at).to be_present
+
+    server.update!(name: "staging-database-108", label_and_taint_job_completed_at: nil)
+
+    kubectl_mock = Kubectl.new("kubeconf")
+
+    expect(kubectl_mock).to receive(:run).with("get node staging-database-108")
+      .and_return([true, "", ""])
+    expect(kubectl_mock).to receive(:run).with("label node staging-database-108 --overwrite node-role.kubernetes.io/database=")
+      .and_return([true, "", ""])
+    expect(kubectl_mock).to receive(:run).with("taint node staging-database-108 role=database:NoSchedule")
+      .and_return([true, "", ""])
+
+    allow_any_instance_of(Server).to receive(:kubectl).and_return(kubectl_mock)
+
+    LabelAndTaintJob.perform_now(server.id)
+
+    expect(server.reload.label_and_taint_job_completed_at).to be_present
+  end
+end

--- a/spec/jobs/label_and_taint_job_spec.rb
+++ b/spec/jobs/label_and_taint_job_spec.rb
@@ -2,12 +2,12 @@ RSpec.describe LabelAndTaintJob do
   it "applies labels and taints to a server via kubectl and updates label_and_taint_job_completed_at" do
     LabelAndTaintRule.create!(
       match: "worker",
-      labels: %w[node-role.kubernetes.io/worker=],
+      labels: "node-role.kubernetes.io/worker=",
     )
     LabelAndTaintRule.create!(
       match: "database",
-      labels: %w[node-role.kubernetes.io/database=],
-      taints: %w[role=database:NoSchedule],
+      labels: "node-role.kubernetes.io/database=",
+      taints: "role=database:NoSchedule",
     )
 
     api_key = api_keys(:hetzner_cloud)

--- a/spec/models/label_and_taint_rule_spec.rb
+++ b/spec/models/label_and_taint_rule_spec.rb
@@ -1,0 +1,123 @@
+RSpec.describe LabelAndTaintRule do
+  it "must have at least one label or taint" do
+    message = "must have at least one label or taint"
+
+    latr = LabelAndTaintRule.new
+    latr.validate
+
+    expect(latr.errors[:labels]).to include message
+
+    latr.taints = "key=value:NoSchedule"
+    latr.validate
+
+    expect(latr.errors[:labels]).not_to include message
+
+    latr.taints = nil
+    latr.labels = "key=value"
+    latr.validate
+
+    expect(latr.errors[:taints]).not_to include message
+  end
+
+  it "validates labels to avoid issues with Kubernetes" do
+    latr = LabelAndTaintRule.new
+
+    # Valid label
+    latr.labels = "app=my-app"
+    latr.validate
+    expect(latr.errors[:labels]).to be_empty
+
+    # Invalid label: missing equals sign
+    latr.labels = "appmy-app"
+    latr.validate
+    expect(latr.errors[:labels]).to include "must include an equals sign to separate key and value"
+
+    # Invalid label: key too long
+    latr.labels = "a" * 317 + "=value"
+    latr.validate
+    expect(latr.errors[:labels]).to include "keys must be between 1 and 316 characters long"
+
+    # Invalid label: key does not start and end with alphanumeric
+    latr.labels = "app-@my-app=value"
+    latr.validate
+    expect(latr.errors[:labels]).to include "keys must consist of alphanumeric characters, '-', '_', '/' or '.', and must start and end with an alphanumeric character (this validation is stricter than Kubernetes itself but let's be reasonable)." # rubocop:disable Layout/LineLength
+
+    # Invalid label: value does not start and end with alphanumeric
+    latr.labels = "app=my-app-@"
+    latr.validate
+    expect(latr.errors[:labels]).to include "values must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character." # rubocop:disable Layout/LineLength
+  end
+
+  it "validates taints to avoid issues with Kubernetes" do
+    latr = LabelAndTaintRule.new
+
+    # Valid taint
+    latr.taints = "key=value:NoSchedule"
+    latr.validate
+    expect(latr.errors[:taints]).to be_empty
+
+    # Invalid taint: missing effect
+    latr.taints = "key=value"
+    latr.validate
+    expect(latr.errors[:taints]).to include "must be in the format of key=value:Effect"
+
+    # Invalid taint: invalid effect
+    latr.taints = "key=value:InvalidEffect"
+    latr.validate
+    expect(latr.errors[:taints]).to include "effect must be one of: NoSchedule, PreferNoSchedule, NoExecute"
+
+    # Invalid taint: missing equals sign
+    latr.taints = "keyvalue:NoSchedule"
+    latr.validate
+    expect(latr.errors[:taints]).to include "must include an equals sign to separate key and value"
+
+    # Invalid taint: key does not start with alphanumeric
+    latr.taints = "-key=value:NoSchedule"
+    latr.validate
+    expect(latr.errors[:taints]).to include "keys must consist of alphanumeric characters, '-', '_', '/' or '.', and must start and end with an alphanumeric character (this validation is stricter than Kubernetes itself but let's be reasonable)." # rubocop:disable Layout/LineLength
+
+    # Invalid taint: key too long
+    latr.taints = "a" * 317 + "=value:NoSchedule"
+    latr.validate
+    expect(latr.errors[:taints]).to include "keys must be between 1 and 316 characters long"
+
+    # Invalid taint: value does not start and end with alphanumeric
+    latr.taints = "key=value-@:NoSchedule"
+    latr.validate
+    expect(latr.errors[:taints]).to include "values must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character." # rubocop:disable Layout/LineLength
+  end
+
+  describe "#labels_as_array" do
+    it "returns an array of labels" do
+      latr = LabelAndTaintRule.new(labels: "app=my-app,env=production")
+      expect(latr.labels_as_array).to eq(["app=my-app", "env=production"])
+    end
+
+    it "returns an empty array if labels are nil" do
+      latr = LabelAndTaintRule.new(labels: nil)
+      expect(latr.labels_as_array).to eq([])
+    end
+
+    it "returns an empty array if labels are empty" do
+      latr = LabelAndTaintRule.new(labels: "")
+      expect(latr.labels_as_array).to eq([])
+    end
+  end
+
+  describe "#taints_as_array" do
+    it "returns an array of taints" do
+      latr = LabelAndTaintRule.new(taints: "key=value:NoSchedule,key2=value2:PreferNoSchedule")
+      expect(latr.taints_as_array).to eq(["key=value:NoSchedule", "key2=value2:PreferNoSchedule"])
+    end
+
+    it "returns an empty array if taints are nil" do
+      latr = LabelAndTaintRule.new(taints: nil)
+      expect(latr.taints_as_array).to eq([])
+    end
+
+    it "returns an empty array if taints are empty" do
+      latr = LabelAndTaintRule.new(taints: "")
+      expect(latr.taints_as_array).to eq([])
+    end
+  end
+end


### PR DESCRIPTION
Define label and taint rules:
<img width="1141" height="547" alt="Screenshot 2025-07-24 at 10 02 40" src="https://github.com/user-attachments/assets/5feefcd5-4de2-4448-8152-0c42f5e09d90" />
<img width="1140" height="768" alt="Screenshot 2025-07-24 at 10 06 57" src="https://github.com/user-attachments/assets/166dea6a-df49-4d48-9810-fdd9b455c87e" />

Have labels and taints applied automatically after a matching server is successfully configured and joins a cluster:
<img width="1792" height="957" alt="label-and-taint-job" src="https://github.com/user-attachments/assets/e5a339cb-1b4e-4760-bd70-722b8d5ac537" />
