### PR TITLE
Allow disk selection and disk wiping before bootstrap

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,15 +1,9 @@
 - Auto sync once per minute or so
 - Realtime bootstrapping log
-- Surface UUID bootstrapping error in frontend
 - Better tracking of rescue mode
 - Better tracking of bootstrapping
 - Change name from Server::HetznerDedicated to Server::HetznerRobot
 - Primary key on servers should probably be compound key of type + id in case robot and cloud servers end up sharing ID
-
-- Option to select a disk and wipe FS before installing
-sfdisk --delete /dev/nvme0n1
-wipefs -a -f /dev/nvme0n1
-
 - Support RAID
 
 mdadm --create --verbose /dev/md0 --level=0 --raid-devices=2 /dev/nvme2n1 /dev/nvme0n1

--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -39,17 +39,22 @@ class ServersController < ApplicationController
 
     talos_version = params.expect(:talos_version)
     talos_image_factory_schematic_id = params[:talos_image_factory_schematic_id]
+    bootstrap_disk_wwid = params.expect(:bootstrap_disk_wwid)
+    bootstrap_disk_name = server.lsblk.fetch("blockdevices").find { it.fetch("wwn") == bootstrap_disk_wwid }.fetch("name")
+    wipe_disk = params.expect(:wipe_bootstrap_disk) == "1"
 
     # pretend it's not accessible while bootstrapping to hide bootstrap button
     server.update!(
       accessible: false,
+      bootstrap_disk_wwid:,
+      bootstrap_disk: "/dev/#{bootstrap_disk_name}",
       label_and_taint_job_completed_at: nil,
       last_configured_at: nil,
       last_request_for_configuration_at: nil,
       talos_image_factory_schematic_id:,
     )
 
-    ServerBootstrapJob.perform_later(server.id, talos_version:)
+    ServerBootstrapJob.perform_later(server.id, talos_version:, wipe_disk:)
 
     redirect_to servers_path, notice: "Server #{server.name} is being bootstrapped"
   end

--- a/app/form_builders/application_form_builder.rb
+++ b/app/form_builders/application_form_builder.rb
@@ -35,6 +35,19 @@ class ApplicationFormBuilder < ActionView::Helpers::FormBuilder
     input_with_label_and_validation(attribute, options) { super }
   end
 
+  def check_box(attribute, options = {}, checked_value = "1", unchecked_value = "0")
+    options[:class] = "mr-1"
+    label_text = options.delete(:label) || attribute.to_s.humanize
+    hint = options[:hint] && %(<p class="text-sm text-gray-400 -mt-2 mb-4">#{options.delete(:hint)}</p>)
+    checkbox = super
+
+    label = label(attribute, nil, class: "block mb-5 font-bold") do
+      "#{checkbox} #{label_text}".html_safe
+    end
+
+    "#{label}#{hint}".html_safe
+  end
+
   def select(attribute, choices = nil, options = {}, html_options = {})
     html_options[:class] = "#{INPUT_CLASSES} appearance-none"
     # Inline CSS SVG background for custom caret

--- a/app/jobs/server_bootstrap_job.rb
+++ b/app/jobs/server_bootstrap_job.rb
@@ -1,8 +1,8 @@
 class ServerBootstrapJob < ApplicationJob
-  def perform(server_id, talos_version:)
+  def perform(server_id, talos_version:, wipe_disk:)
     server = Server.find_by_id(server_id)
     return unless server
 
-    server.bootstrap!(talos_version:)
+    server.bootstrap!(talos_version:, wipe_disk:)
   end
 end

--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -35,14 +35,23 @@ class Server < ApplicationRecord
     end
   }
 
-  def talos_type
-    name.include?("control-plane") ? "controlplane" : "worker"
+  # #bootstrap_metadata must be implemented in every subclasses of Server.
+  # Should return a hash populated with:
+  # {
+  #   bootstrappable: <true/false> (eg. for Hetzner servers this is true if the server is in rescue mode),
+  #   uuid: "<output from dmidecode -s system-uuid>",
+  #   lsblk: { <JSON parsed output from lsblk --output NAME,TYPE,SIZE,UUID,MODEL,WWN --bytes --json> },
+  # }
+  def bootstrap_metadata
+    raise "#bootstrap_metadata is not implemented for #{self.class.name}"
   end
 
-  # Implement #bootstrappable? in subclasses of Server. Eg. for Hetzner servers this is
-  # true when servers are in rescue mode and SSH is accessible.
   def bootstrappable?
-    raise "#bootstrappable? is not implemented for #{self.class.name}"
+    bootstrap_metadata.fetch(:bootstrappable)
+  end
+
+  def talos_type
+    name.include?("control-plane") ? "controlplane" : "worker"
   end
 
   # NOTE: Doesn't necessarily imply that the server was successfully bootstrapped after config was sent

--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -66,35 +66,15 @@ class Server < ApplicationRecord
   # wget $TALOS_IMAGE_URL --quiet -O - | zstd -d | dd of=/dev/$DEVICE status=progress
   # sync
   # reboot
-  def bootstrap!(talos_version:)
-    raise "ERROR: Can't bootstrap without a HOST configured" unless HOST
-
+  def bootstrap!(talos_version:, wipe_disk: false)
     session = Net::SSH.start(ip, "root", key_data: [ENV.fetch("SSH_PRIVATE_KEY")])
-    uuid = session.exec! "dmidecode -s system-uuid".chomp
-    if uuid.include? "-000000000000"
-      system_data = session.exec! "dmidecode -t system"
-      raise "Invalid SMBIOS UUID, send this output to Hetzner support: #{system_data}"
-    end
-
     talos_image_url = bootstrap_image_url(talos_version:)
-    lsblk = JSON.parse(session.exec!("lsblk --output NAME,TYPE,SIZE,UUID,MODEL,WWN --bytes --json"))
-    disks = lsblk.fetch("blockdevices").select { it.fetch("type") == "disk" }
 
-    # Exclude disks with children (partitions or RAID devices)
-    noneligble, eligble = disks.partition { |disk| disk.key?("children") }
-
-    Rails.logger.info "Ignoring non-eligible disks: #{noneligble.map { it.fetch('name') }.join(', ')}"
-    raise "No eligible disks found for bootstrapping" if eligble.empty?
-
-    Rails.logger.info "Eligible disks for bootstrapping: #{eligble.map { it.fetch('name') }.join(', ')}"
-
-    eligble.sort_by! { it.fetch("name") }
-    first_nvme = eligble.find { it.fetch("name").start_with?("nvme") }
-    bootstrap_disk_data = first_nvme || eligble.first
-    bootstrap_disk = "/dev/#{bootstrap_disk_data.fetch('name')}"
-    bootstrap_disk_wwid = bootstrap_disk_data.fetch("wwn")
-
-    update!(bootstrap_disk:, bootstrap_disk_wwid:, uuid:)
+    if wipe_disk
+      Rails.logger.info "Wiping disk #{bootstrap_disk} before bootstrapping"
+      ssh_exec_with_log! session, "sfdisk --delete #{bootstrap_disk}"
+      ssh_exec_with_log! session, "wipefs -a #{bootstrap_disk}"
+    end
 
     Rails.logger.info "Bootstrapping #{ip} with talos image #{talos_image_url} on #{bootstrap_disk}"
     ssh_exec_with_log! session, "wget #{talos_image_url} --quiet -O - | zstd -d | dd of=#{bootstrap_disk} status=progress"

--- a/app/models/server/hetzner_cloud.rb
+++ b/app/models/server/hetzner_cloud.rb
@@ -1,18 +1,22 @@
 class Server::HetznerCloud < Server
-  def bootstrappable?
-    session = Net::SSH.start(
-      ip,
-      "root",
-      key_data: [ENV.fetch("SSH_PRIVATE_KEY")],
-      non_interactive: true,
-      verify_host_key: :never,
-      timeout: 2,
-    )
+  def bootstrap_metadata
+    return @bootstrap_metadata if defined?(@bootstrap_metadata)
+
+    key_data = [ENV.fetch("SSH_PRIVATE_KEY")]
+    session = Net::SSH.start(ip, "root", key_data:, non_interactive: true, verify_host_key: :never, timeout: 2)
     hostname = session.exec!("hostname")
-    session.close
-    hostname.include?("rescue")
+    bootstrappable = hostname.include?("rescue")
+
+    # Populate bootstrap_metadata with necessary information
+    if bootstrappable
+      uuid = session.exec!("dmidecode -s system-uuid").chomp
+      lsblk_output = session.exec!("lsblk --output NAME,TYPE,SIZE,UUID,MODEL,WWN --bytes --json")
+      lsblk = JSON.parse(lsblk_output)
+    end
+
+    @bootstrap_metadata = { bootstrappable:, uuid:, lsblk: }
   rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Net::SSH::AuthenticationFailed, Net::SSH::ConnectionTimeout
-    false
+    @bootstrap_metadata = { bootstrappable: false, uuid: nil, lsblk: nil }
   ensure
     session&.shutdown!
   end

--- a/app/views/servers/prepare_bootstrap.html.erb
+++ b/app/views/servers/prepare_bootstrap.html.erb
@@ -1,31 +1,58 @@
 <%= turbo_frame_tag "servers-actions-dialog" do %>
-  <dialog id="server-actions-dialog" class="backdrop:backdrop-blur-sm backdrop:bg-gray-100 backdrop:bg-opacity-30 p-6 rounded-lg shadow-lg">
+  <dialog id="server-actions-dialog" class="max-w-[60rem] backdrop:backdrop-blur-sm backdrop:bg-gray-100 backdrop:bg-opacity-30 p-6 rounded-lg shadow-lg">
     <form method="dialog" class="flex mb-4">
       <h2 class="text-2xl mr-5">Bootstrap server: <%= @server.name %></h2>
       <button class="ml-auto text-gray-500 hover:text-gray-700"><%= icon_close %></button>
     </form>
-    <%= form_with url: bootstrap_server_path, data: { turbo_frame: "_top" } do |f| %>
-      <%=
-        f.select(
-          :talos_version,
-          sorted_talos_versions,
-          { include_blank: false, selected: TalosImageFactorySetting.singleton.version },
-          class: "w-full mb-4",
-          required: false,
-        )
-      %>
-      <%=
-        f.select(
-          :talos_image_factory_schematic_id,
-          TalosImageFactorySchematic.order(:name).pluck(:name, :id),
-          { include_blank: "none", selected: TalosImageFactorySetting.singleton.schematic_id },
-          class: "w-full mb-4",
-          label: "Talos Image Factory Schematic",
-          required: false,
-          hint: "Use the #{link_to('Talos Schematics', talos_image_factory_schematics_path, class: 'text-blue-600 hover:underline', data: { turbo_frame: '_top'})} page to create custom schematics.",
-        )
-      %>
-      <%= f.submit "Bootstrap!" %>
+    <% if @server.uuid.to_s.include?("-000000000000") %>
+      <p class="text-red-500 mb-4">
+        ERROR: The UUID of this server '<%= @server.uuid %>' appears invalid. We have found that the motherboards of certain dedicated Hetzner servers have not been properly initialized. Reach out to their support and they should be able to fix this. Talos manager does not allow bootstraping with a faulty UUID since it prevents Talos configuration from being successful in case eg. NodeID based LUKS encryption is enabled.
+      </p>
+    <% else %>
+      <%= form_with url: bootstrap_server_path, data: { turbo_frame: "_top" } do |f| %>
+        <%=
+          f.select(
+            :talos_version,
+            sorted_talos_versions,
+            { include_blank: false, selected: TalosImageFactorySetting.singleton.version },
+            class: "w-full mb-4",
+            required: false,
+          )
+        %>
+        <%=
+          f.select(
+            :talos_image_factory_schematic_id,
+            TalosImageFactorySchematic.order(:name).pluck(:name, :id),
+            { include_blank: "none", selected: TalosImageFactorySetting.singleton.schematic_id },
+            class: "w-full mb-4",
+            label: "Talos Image Factory Schematic",
+            required: false,
+            hint: "Use the #{link_to('Talos Schematics', talos_image_factory_schematics_path, class: 'text-blue-600 hover:underline', data: { turbo_frame: '_top'})} page to create custom schematics.",
+          )
+        %>
+
+        <% disks = @server.lsblk.fetch("blockdevices").select { |disk| disk['type'] == "disk" } %>
+        <%=
+          f.select(
+            :bootstrap_disk_wwid,
+            disks
+              .map { |disk| ["/dev/#{disk['name']} (#{number_to_human_size(disk['size'])})", disk.fetch('wwn')] }
+              .sort_by(&:first),
+            {
+              include_blank: false,
+              disabled: disks
+                .select do |disk|
+                  disk.fetch("children", []).any? { it.fetch("type").start_with?("raid") }
+                end
+                .map { it.fetch("wwn") },
+            },
+            required: false,
+            label: "Bootstrap disk",
+          )
+        %>
+        <%= f.check_box :wipe_bootstrap_disk, hint: "If enabled will run sfdisk --delete and wipefs -a -f on the device before installing." %>
+        <%= f.submit "Bootstrap!" %>
+      <% end %>
     <% end %>
   </dialog>
 

--- a/db/migrate/20250728135005_add_lsblk_to_servers.rb
+++ b/db/migrate/20250728135005_add_lsblk_to_servers.rb
@@ -1,0 +1,5 @@
+class AddLsblkToServers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :servers, :lsblk, :jsonb
+  end
+end

--- a/db/migrate/20250728135005_add_lsblk_to_servers.rb
+++ b/db/migrate/20250728135005_add_lsblk_to_servers.rb
@@ -1,5 +1,6 @@
 class AddLsblkToServers < ActiveRecord::Migration[8.0]
   def change
-    add_column :servers, :lsblk, :jsonb
+    # NOTE: Would use jsonb but SQLite doesn't support it at the moment 😭
+    add_column :servers, :lsblk, :json
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_28_075647) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_28_135005) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -96,6 +96,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_28_075647) do
     t.string "bootstrap_disk_wwid"
     t.datetime "label_and_taint_job_completed_at"
     t.bigint "talos_image_factory_schematic_id"
+    t.jsonb "lsblk"
     t.index ["api_key_id"], name: "index_servers_on_api_key_id"
     t.index ["cluster_id"], name: "index_servers_on_cluster_id"
     t.index ["hetzner_vswitch_id"], name: "index_servers_on_hetzner_vswitch_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -96,7 +96,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_28_135005) do
     t.string "bootstrap_disk_wwid"
     t.datetime "label_and_taint_job_completed_at"
     t.bigint "talos_image_factory_schematic_id"
-    t.jsonb "lsblk"
+    t.json "lsblk"
     t.index ["api_key_id"], name: "index_servers_on_api_key_id"
     t.index ["cluster_id"], name: "index_servers_on_cluster_id"
     t.index ["hetzner_vswitch_id"], name: "index_servers_on_hetzner_vswitch_id"

--- a/spec/fixtures/api_keys.yml
+++ b/spec/fixtures/api_keys.yml
@@ -2,3 +2,7 @@ hetzner_cloud:
   provider: hetzner_cloud
   name: hetzner-cloud
   secret: token
+hetzner_robot:
+  provider: hetzner_robot
+  name: hetzner-robot
+  secret: token

--- a/spec/fixtures/files/hetzner-cloud-servers.json
+++ b/spec/fixtures/files/hetzner-cloud-servers.json
@@ -1,0 +1,42 @@
+{
+  "servers": [
+    {
+      "id": 1,
+      "name": "worker-1",
+      "status": "running",
+      "public_net": {
+        "ipv4": { "ip": "37.27.31.1" },
+        "ipv6": { "ip": "::1" }
+      },
+      "server_type": {
+        "name": "cpx31",
+        "architecture": "x86"
+      },
+      "datacenter": { "name": "hel-dc1" }
+    },
+    {
+      "id": 2,
+      "name": "worker-2",
+      "status": "running",
+      "public_net": {
+        "ipv4": { "ip": "37.27.31.2" },
+        "ipv6": { "ip": "::2" }
+      },
+      "server_type": {
+        "name": "cax21",
+        "architecture": "arm"
+      },
+      "datacenter": { "name": "hel-dc2" }
+    }
+  ],
+  "meta": {
+    "pagination": {
+      "page": 1,
+      "per_page": 50,
+      "previous_page": null,
+      "next_page": null,
+      "last_page": 1,
+      "total_entries": 2
+    }
+  }
+}

--- a/spec/fixtures/files/hetzner-robot-servers.json
+++ b/spec/fixtures/files/hetzner-robot-servers.json
@@ -1,0 +1,26 @@
+[
+  {
+    "server": {
+      "server_number": 3,
+      "product": "AX52",
+      "cancelled": false,
+      "dc": "hel-dc1",
+      "server_ip": "123.123.123.1",
+      "server_ipv6_net": "::3",
+      "server_name": "worker-3",
+      "status": "running"
+    }
+  },
+  {
+    "server": {
+      "server_number": 4,
+      "product": "RX220",
+      "cancelled": false,
+      "dc": "hel-dc2",
+      "server_ip": "123.123.123.2",
+      "server_ipv6_net": "::4",
+      "server_name": "worker-4",
+      "status": "running"
+    }
+  }
+]

--- a/spec/fixtures/servers.yml
+++ b/spec/fixtures/servers.yml
@@ -1,5 +1,7 @@
 cloud_bootstrappable:
   api_key: hetzner_cloud
+  bootstrap_disk: /dev/nvme0n1
+  bootstrap_disk_wwid: wwid-worker-1
   cluster: default
   type: Server::HetznerCloud
   name: worker-1
@@ -9,6 +11,22 @@ cloud_bootstrappable:
   ipv6: "::1"
   product: cpx31
   status: running
+  uuid: 123e4567-e89b-12d3-a456-426614174000
+  lsblk:
+    {
+      "blockdevices": [
+        {
+          "name": "nvme0n1",
+          "wwn": "wwid-worker-1",
+          "size": "1000000000",
+        },
+        {
+          "name": "nvme1n1",
+          "wwn": "wwid-worker-1-data",
+          "size": "1000000000",
+        }
+      ]
+    }
 
 cloud_botstrapped:
   api_key: hetzner_cloud

--- a/spec/requests/servers_controller_spec.rb
+++ b/spec/requests/servers_controller_spec.rb
@@ -6,6 +6,106 @@ RSpec.describe "ServersController" do
     end
   end
 
+  describe "POST /admin/servers/sync" do
+    it "syncs servers with the provider and redirects back to index" do
+      lsblk_output = File.read("spec/fixtures/files/lsblk.json")
+
+      # Hetzner Robot API key requests
+      hetzner_robot_response = File.read("spec/fixtures/files/hetzner-robot-servers.json")
+      stub_request(:get, "https://robot-ws.your-server.de/vswitch")
+        .to_return(status: 200, body: "[]")
+      stub_request(:get, "https://robot-ws.your-server.de/server")
+        .to_return(status: 200, body: hetzner_robot_response)
+
+      # Hetzner Cloud API key requests
+      hetzner_cloud_response = File.read("spec/fixtures/files/hetzner-cloud-servers.json")
+      stub_request(:get, "https://api.hetzner.cloud/v1/servers?per_page=50")
+        .to_return(status: 200, body: hetzner_cloud_response)
+
+      # Make the first cloud server bootstrappable
+      ssh_session_mock = instance_double(Net::SSH::Connection::Session)
+      expect(ssh_session_mock).to receive(:exec!)
+        .with("hostname")
+        .and_return("rescue\n")
+      expect(ssh_session_mock).to receive(:exec!)
+        .with("dmidecode -s system-uuid")
+        .and_return("123e4567-e89b-12d3-a456-426614174000\n")
+      expect(ssh_session_mock).to receive(:exec!)
+        .with("lsblk --output NAME,TYPE,SIZE,UUID,MODEL,WWN --bytes --json")
+        .and_return(lsblk_output)
+      expect(ssh_session_mock).to receive(:shutdown!)
+
+      hetzner_cloud_servers = JSON.parse(hetzner_cloud_response)
+
+      key_data = [ENV.fetch("SSH_PRIVATE_KEY")]
+      first_server_ip = hetzner_cloud_servers.dig("servers", 0, "public_net", "ipv4", "ip")
+      expect(Net::SSH).to receive(:start)
+        .with(first_server_ip, "root", key_data:, non_interactive: true, verify_host_key: :never, timeout: 2)
+        .and_return(ssh_session_mock)
+
+      second_server_ip = hetzner_cloud_servers.dig("servers", 1, "public_net", "ipv4", "ip")
+      expect(Net::SSH).to receive(:start)
+        .with(second_server_ip, "root", key_data:, non_interactive: true, verify_host_key: :never, timeout: 2)
+        .and_raise(Errno::ECONNREFUSED)
+
+      # Make the first robot server bootstrappable
+      ssh_robot_session_mock = instance_double(Net::SSH::Connection::Session)
+      expect(ssh_robot_session_mock).to receive(:exec!)
+        .with("hostname")
+        .and_return("rescue\n")
+      expect(ssh_robot_session_mock).to receive(:exec!)
+        .with("dmidecode -s system-uuid")
+        .and_return("63391acf-ceb9-1891-72fc-c87f545220d8\n")
+      expect(ssh_robot_session_mock).to receive(:exec!)
+        .with("lsblk --output NAME,TYPE,SIZE,UUID,MODEL,WWN --bytes --json")
+        .and_return(lsblk_output)
+      expect(ssh_robot_session_mock).to receive(:shutdown!)
+
+      hetzner_robot_servers = JSON.parse(hetzner_robot_response)
+
+      first_robot_server_ip = hetzner_robot_servers.dig(0, "server", "server_ip")
+      expect(Net::SSH).to receive(:start)
+        .with(first_robot_server_ip, "root", key_data:, non_interactive: true, verify_host_key: :never, timeout: 2)
+        .and_return(ssh_robot_session_mock)
+
+      second_robot_server_ip = hetzner_robot_servers.dig(1, "server", "server_ip")
+      expect(Net::SSH).to receive(:start)
+        .with(second_robot_server_ip, "root", key_data:, non_interactive: true, verify_host_key: :never, timeout: 2)
+        .and_raise(Errno::ECONNREFUSED)
+
+      post "/admin/servers/sync"
+
+      expect(Server.count).to eq 4
+
+      expect(Server.find_by!(name: "worker-1")).to have_attributes(
+        accessible: true,
+        uuid: "123e4567-e89b-12d3-a456-426614174000",
+        lsblk: JSON.parse(lsblk_output),
+      )
+
+      expect(Server.find_by!(name: "worker-2")).to have_attributes(
+        accessible: false,
+        uuid: nil,
+        lsblk: nil,
+      )
+
+      expect(Server.find_by!(name: "worker-3")).to have_attributes(
+        accessible: true,
+        uuid: "63391acf-ceb9-1891-72fc-c87f545220d8",
+        lsblk: JSON.parse(lsblk_output),
+      )
+
+      expect(Server.find_by!(name: "worker-4")).to have_attributes(
+        accessible: false,
+        uuid: nil,
+        lsblk: nil,
+      )
+
+      expect(response).to redirect_to servers_path
+      expect(flash[:notice]).to be_present
+    end
+  end
+
   describe "GET /admin/servers/<server-id>/prepare_bootstrap" do
     it "returns http success" do
       server = servers(:cloud_bootstrappable)
@@ -16,7 +116,7 @@ RSpec.describe "ServersController" do
   end
 
   describe "POST /admin/servers/<server-id>/bootstrap" do
-    it "returns http redirect" do
+    it "enqueues the bootstrapping job, updates the server and redirects back to servers" do
       server = servers(:cloud_bootstrappable)
       talos_version = "v1.10.5"
 
@@ -34,19 +134,19 @@ RSpec.describe "ServersController" do
         talos_image_factory_schematic_id: talos_image_factory_schematics(:default).id,
       }
 
-      server.reload
-      expect(server).to have_attributes(
+      # Check that the ServerBootstrapJob was enqueued
+      expect(ServerBootstrapJob).to have_been_enqueued.with(server.id, talos_version:)
+
+      expect(server.reload).to have_attributes(
         accessible: false,
         label_and_taint_job_completed_at: nil,
         last_configured_at: nil,
         last_request_for_configuration_at: nil,
         talos_image_factory_schematic_id: talos_image_factory_schematics(:default).id,
       )
+
       expect(response).to redirect_to servers_path
       expect(flash[:notice]).to be_present
-
-      # Check that the ServerBootstrapJob was enqueued
-      expect(ServerBootstrapJob).to have_been_enqueued.with(server.id, talos_version:)
     end
   end
 


### PR DESCRIPTION
When syncing servers, `lsblk` output will now be synced to a `servers.lsblk` JSON column along with `uuid` for bootstrappable servers. This allows us to present a disk selection dropdown in the bootstrap modal:

<img width="1133" height="823" alt="Screenshot 2025-07-31 at 10 53 02" src="https://github.com/user-attachments/assets/32c8e480-542a-4e5c-9925-7380b1b47ceb" />

A "Wipe disk" checkbox can be toggled to fully wipe the selected disk before bootstrapping, making it more straight forward to re-bootstrap servers which have had OS'es previously installed.

This also allows us to surface potential UUID errors in the UI before starting the bootstrap job.