### PR TITLE
Wiping bootstrap disk no longer optional but warn if partitions exist

### DIFF
--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -41,7 +41,6 @@ class ServersController < ApplicationController
     talos_image_factory_schematic_id = params[:talos_image_factory_schematic_id]
     bootstrap_disk_wwid = params.expect(:bootstrap_disk_wwid)
     bootstrap_disk_name = server.lsblk.fetch("blockdevices").find { it.fetch("wwn") == bootstrap_disk_wwid }.fetch("name")
-    wipe_disk = params.expect(:wipe_bootstrap_disk) == "1"
 
     # pretend it's not accessible while bootstrapping to hide bootstrap button
     server.update!(
@@ -54,7 +53,7 @@ class ServersController < ApplicationController
       talos_image_factory_schematic_id:,
     )
 
-    ServerBootstrapJob.perform_later(server.id, talos_version:, wipe_disk:)
+    ServerBootstrapJob.perform_later(server.id, talos_version:)
 
     redirect_to servers_path, notice: "Server #{server.name} is being bootstrapped"
   end

--- a/app/jobs/server_bootstrap_job.rb
+++ b/app/jobs/server_bootstrap_job.rb
@@ -1,8 +1,8 @@
 class ServerBootstrapJob < ApplicationJob
-  def perform(server_id, talos_version:, wipe_disk:)
+  def perform(server_id, talos_version:)
     server = Server.find_by_id(server_id)
     return unless server
 
-    server.bootstrap!(talos_version:, wipe_disk:)
+    server.bootstrap!(talos_version:)
   end
 end

--- a/app/views/servers/prepare_bootstrap.html.erb
+++ b/app/views/servers/prepare_bootstrap.html.erb
@@ -36,21 +36,47 @@
           f.select(
             :bootstrap_disk_wwid,
             disks
-              .map { |disk| ["/dev/#{disk['name']} (#{number_to_human_size(disk['size'])})", disk.fetch('wwn')] }
+              .filter_map do |disk|
+                partitions = disk.fetch("children", []).select { |it| it.fetch("type").start_with?("part") }
+                partitions_suffix = "[#{partitions.length} existing partition#{'s' if partitions.length != 1}]"
+                label = "/dev/#{disk['name']} (#{number_to_human_size(disk['size'])}) #{partitions_suffix}"
+                value = disk.fetch("wwn")
+
+                [label, value]
+              end
               .sort_by(&:first),
             {
-              include_blank: false,
+              prompt: "Select a disk to bootstrap",
+              # the first non raided disk should be selected by default
+              selected: disks
+                .reject { |disk| disk.fetch("children", []).any? { it.fetch("type").start_with?("raid") } }
+                .first&.fetch("wwn"),
               disabled: disks
                 .select do |disk|
                   disk.fetch("children", []).any? { it.fetch("type").start_with?("raid") }
                 end
                 .map { it.fetch("wwn") },
             },
-            required: false,
+            onchange: "
+              if(!this.value || parseInt(this.selectedOptions[0].innerText.split('[')[1][0]) == 0)
+                document.getElementById('bootstrap-warning').classList.add('hidden')
+              else
+                document.getElementById('bootstrap-warning').classList.remove('hidden')
+            ",
+            required: true,
             label: "Bootstrap disk",
           )
         %>
-        <%= f.check_box :wipe_bootstrap_disk, hint: "If enabled will run sfdisk --delete and wipefs -a -f on the device before installing." %>
+
+        <p id="bootstrap-warning" class="bg-yellow-100 text-yellow-800 p-4 rounded mb-4 hidden border border-yellow-200">
+          <strong>Warning:</strong> Existing partitions on the selected disk will be wiped.
+        </p>
+
+        <script>
+          // Trigger change event to show/hide the warning based on the initially selected disk
+          document.getElementById("bootstrap_disk_wwid").dispatchEvent(new Event("change"))
+        </script>
+
         <%= f.submit "Bootstrap!" %>
       <% end %>
     <% end %>

--- a/spec/requests/servers_controller_spec.rb
+++ b/spec/requests/servers_controller_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe "ServersController" do
       expect(flash[:notice]).to be_present
 
       # Check that the ServerBootstrapJob was enqueued
-      expect(ServerBootstrapJob).to have_been_enqueued.with(server.id, talos_version:, wipe_disk: false)
+      expect(ServerBootstrapJob).to have_been_enqueued.with(server.id, talos_version:)
 
       expect(server.reload).to have_attributes(
         accessible: false,


### PR DESCRIPTION
On second thought wiping the bootstrap disk should be mandatory since it's the only way to guarantee a non-corrupted disk after `dd` completes writing the raw talos image to the disk.

<img width="506" height="180" alt="Screenshot 2025-07-31 at 12 48 54" src="https://github.com/user-attachments/assets/1e5dc6f6-9971-46a4-8035-9aa344dd8679" />
