### PR TITLE
Support VolumeConfig for EPHEMERAL partition including RAID devices

### DIFF
--- a/app/controllers/machine_configs_controller.rb
+++ b/app/controllers/machine_configs_controller.rb
@@ -24,6 +24,7 @@ class MachineConfigsController < ApplicationController
       :private_ip,
       :already_configured,
       :install_disk,
+      :ephemeral_disk_identifier,
     )
     @machine_config = MachineConfig.new(machine_config_params)
     @server = @machine_config.server

--- a/app/views/machine_configs/new.html.erb
+++ b/app/views/machine_configs/new.html.erb
@@ -5,7 +5,49 @@
 
   <%= f.text_field :hostname, required: true, placeholder: "worker-x", hint: "Will substitute ${hostname} in your config patches." %>
   <%= f.text_field :private_ip, required: true, placeholder: "10.0.x.x", label: "Private IP", hint: "Will substitute ${private_ip} in your config patches." %>
-  <%= f.text_field :install_disk, required: true, placeholder: "/dev/sda", hint: "Gets passed into the --install-disk argument for talosctl gen config." %>
+  <% if f.object.server.lsblk.present? %>
+    <%= f.text_field :install_disk, required: true, disabled: true, hint: "Gets passed into the --install-disk argument for talosctl gen config. Non modifiable: must use the same disk which was used for bootstrapping." %>
+    <%
+      # - RAID devices are listed as children of disks
+      # - UUID of disks containing RAID devices are actually the UUID of the RAID device
+      # Hence we reduce RAID disks to a single entry per RAID device, using their UUID as value.
+      disks = f.object.server.lsblk.fetch("blockdevices").select { |disk| disk.fetch("type") == "disk" }
+      raids, other = disks.partition { |disk| disk.fetch("children", []).any? { |child| child.fetch("type").start_with?("raid") } }
+      raids = raids
+        .group_by { |disk| disk.fetch("children").find { |child| child.fetch("type").start_with?("raid") }&.fetch("name") }
+        .map do |raid_name, disks|
+          raid = disks.first.fetch("children").find { |child| child.fetch("type").start_with?("raid") }
+          type = raid.fetch("type").upcase
+          label = "/dev/#{raid_name} (#{number_to_human_size(raid.fetch('size'))}) [#{type}]"
+          value = disks.first.fetch("uuid")
+
+          [label, "uuid:#{value}"]
+        end
+      other = other
+        .reject { |disk| disk.fetch("wwn") == f.object.server.bootstrap_disk_wwid }
+        .map do |disk|
+          partitions = disk.fetch("children", []).select { it.fetch("type").start_with?("part") }
+          suffix = partitions.empty? ? "" : "[#{partitions.length} existing partition#{'s' if partitions.length != 1}]"
+          label = "/dev/#{disk['name']} (#{number_to_human_size(disk['size'])}) #{suffix}"
+          value = disk.fetch("wwn")
+
+          [label, "wwid:#{value}"]
+        end
+      ephemeral_disk_options = (raids + other).sort_by(&:first)
+    %>
+    <%=
+      f.select(
+        :ephemeral_disk_identifier,
+        ephemeral_disk_options,
+        { include_blank: "Same as install disk" },
+        required: false,
+        label: "Disk for EPHEMERAL partition (optional)",
+        hint: "If an ephemeral disk is selected, a <a href='https://www.talos.dev/v1.10/reference/configuration/block/volumeconfig/' class='text-blue-500 hover:underline' target='_blank'>VolumeConfig</a> will be added to the server's MachineConfig to use the disk for Talos Linux's EPHEMERAL partition. This is the disk mounted at /var which includes local persistent volumes, so the name ephemeral is misleading. RAID devices will be listed here but note that your Talos Factory Image must contain the <a href='https://github.com/siderolabs/extensions/tree/main/storage/mdadm' target='_blank' class='text-blue-500 hover:underline'>mdadm extension</a> for them to work.",
+      )
+    %>
+  <% else %>
+    <%= f.text_field :install_disk, required: true, placeholder: "/dev/nvme0n1", hint: "Gets passed into the --install-disk argument for talosctl gen config." %>
+  <% end %>
   <%= f.select :config_id, Config.pluck(:name, :id), { include_blank: true }, required: true %>
   <%= f.check_box :already_configured, class: "mr-1", hint: "Check to apply green status to the server immediately" %>
 

--- a/db/migrate/20250804112912_add_ephemeral_disk_identifier_to_machine_configs.rb
+++ b/db/migrate/20250804112912_add_ephemeral_disk_identifier_to_machine_configs.rb
@@ -1,0 +1,5 @@
+class AddEphemeralDiskIdentifierToMachineConfigs < ActiveRecord::Migration[8.0]
+  def change
+    add_column :machine_configs, :ephemeral_disk_identifier, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_28_135005) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_04_112912) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -69,6 +69,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_28_135005) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "install_disk", default: "/dev/sda", null: false
+    t.string "ephemeral_disk_identifier"
     t.index ["config_id"], name: "index_machine_configs_on_config_id"
     t.index ["server_id"], name: "index_machine_configs_on_server_id"
   end

--- a/spec/fixtures/clusters.yml
+++ b/spec/fixtures/clusters.yml
@@ -1,6 +1,6 @@
 default:
   name: default
-  endpoint: http://kubernetes.example.com:6443
+  endpoint: https://kubernetes.example.com:6443
   secrets: |
     cluster:
         id: d4ztP13Cr27K_0eTNQmM0I1_k50EHxci7bT_KROwxrI=


### PR DESCRIPTION
It's now possible to specify a disk to be used for Talos Linux's "EPHEMERAL" partition when applying configuration to a server. Note that this is the partition mounted under `/var` which contains local Persistent Volumes. So the name "ephemeral" can be confusing / misleading.

We can even support RAID devices for this partition, though they require the mdadm extension and you have to create the array manually before bootstrapping. You will also need a minimum of 3 disks for RAID to work since the install disk can't be RAID'ed and therefore must be separate.

<img width="1034" height="914" alt="Screenshot 2025-08-04 at 15 29 04" src="https://github.com/user-attachments/assets/f56d7fd4-42e9-4496-b12d-8441bf2384de" />
